### PR TITLE
Add summary report tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,23 @@ While iterating on your configuration:
 - Create new agent types using the same configuration pattern
 - Debug configuration issues in LangGraph Studio
 
+### `summary_report_tool`
+
+Use this tool to condense conversation into a short structured report.
+
+```python
+await summary_report_tool(
+    "Please approve the purchase of new chairs for the office by next week."
+)
+```
+
+This returns a brief summary, e.g.:
+
+```
+- Request: approve purchase of new chairs
+- Deadline: next week
+```
+
 ## Documentation
 
 You can find the latest LangGraph documentation [here](https://github.com/langchain-ai/langgraph), including examples and references for configuration patterns.

--- a/src/react_agent/configuration.py
+++ b/src/react_agent/configuration.py
@@ -27,7 +27,7 @@ class Configuration(BaseModel):
         "Should be in the form: provider/model-name."
     )
 
-    selected_tools: list[Literal["finance_research", "advanced_research_tool", "basic_research_tool", "get_todays_date", "acronym_tool"]] = Field(
+    selected_tools: list[Literal["finance_research", "advanced_research_tool", "basic_research_tool", "get_todays_date", "acronym_tool", "summary_report_tool"]] = Field(
         default = ["get_todays_date"],
         description="The list of tools to use for the agent's interactions. "
         "This list should contain the names of the tools to use."

--- a/src/react_agent/tools.py
+++ b/src/react_agent/tools.py
@@ -12,6 +12,7 @@ from langchain_community.tools.tavily_search import TavilySearchResults
 from langchain_community.tools.yahoo_finance_news import YahooFinanceNewsTool
 from langchain_core.tools import tool
 from datetime import datetime
+from src.utils import load_chat_model, get_message_text
 
 @tool
 async def finance_research(ticker_symbol: str) -> Optional[list[dict[str, Any]]]:
@@ -67,6 +68,18 @@ async def acronym_tool(phrase: str) -> str:
     return "".join(letters).lower()
 
 
+@tool
+async def summary_report_tool(text: str) -> str:
+    """Generate a short structured summary of the input text."""
+    llm = load_chat_model("openai/gpt-4.1-mini")
+    prompt = (
+        "Please provide a concise structured report summarizing the following text:\n"
+        f"{text}\n"
+    )
+    message = await llm.ainvoke(prompt)
+    return get_message_text(message)
+
+
 def get_tools(selected_tools: list[str]) -> list[Callable[..., Any]]:
     """Convert a list of tool names to actual tool functions."""
     tools = []
@@ -81,5 +94,7 @@ def get_tools(selected_tools: list[str]) -> list[Callable[..., Any]]:
             tools.append(get_todays_date)
         elif tool == "acronym_tool":
             tools.append(acronym_tool)
+        elif tool == "summary_report_tool":
+            tools.append(summary_report_tool)
 
     return tools

--- a/src/supervisor/supervisor_configuration.py
+++ b/src/supervisor/supervisor_configuration.py
@@ -76,7 +76,7 @@ When you are done with your research, return the research to the supervisor agen
         description="The name of the language model to use for the finance sub-agent.",
         json_schema_extra={"langgraph_nodes": ["finance_research_agent"]}
     )
-    finance_tools: list[Literal["finance_research", "advanced_research_tool", "basic_research_tool", "get_todays_date", "acronym_tool"]] = Field(
+    finance_tools: list[Literal["finance_research", "advanced_research_tool", "basic_research_tool", "get_todays_date", "acronym_tool", "summary_report_tool"]] = Field(
         default = ["finance_research", "basic_research_tool", "get_todays_date"],
         description="The list of tools to make available to the finance sub-agent.",
         json_schema_extra={"langgraph_nodes": ["finance_research_agent"]}
@@ -104,7 +104,7 @@ agent. YOU MUST USE THE ADVANCED_RESEARCH_TOOL TO GET THE INFORMATION YOU NEED""
         description="The name of the language model to use for the research sub-agent.",
         json_schema_extra={"langgraph_nodes": ["general_research_agent"]}
     )
-    research_tools: list[Literal["finance_research", "advanced_research_tool", "basic_research_tool", "get_todays_date", "acronym_tool"]] = Field(
+    research_tools: list[Literal["finance_research", "advanced_research_tool", "basic_research_tool", "get_todays_date", "acronym_tool", "summary_report_tool"]] = Field(
         default = ["advanced_research_tool", "get_todays_date"],
         description="The list of tools to make available to the general research sub-agent.",
         json_schema_extra={"langgraph_nodes": ["general_research_agent"]}
@@ -132,7 +132,7 @@ final content based on the requested format for the user, then return the final 
         description="The name of the language model to use for the research sub-agent.",
         json_schema_extra={"langgraph_nodes": ["writing_agent"]}
     )
-    writing_tools: list[Literal["finance_research", "advanced_research_tool", "basic_research_tool", "get_todays_date", "acronym_tool"]] = Field(
+    writing_tools: list[Literal["finance_research", "advanced_research_tool", "basic_research_tool", "get_todays_date", "acronym_tool", "summary_report_tool"]] = Field(
         default = ["advanced_research_tool", "get_todays_date"],
         description="The list of tools to make available to the general research sub-agent.",
         json_schema_extra={"langgraph_nodes": ["writing_agent"]}


### PR DESCRIPTION
## Summary
- add async `summary_report_tool` for generating short reports
- expose `summary_report_tool` through configuration options
- update supervisor and agent configuration schemas
- document the new tool with an example

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686abae4cee88327aec7175e9d136655