### PR TITLE
Update system prompt in Spanish to use summary report tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,17 @@ async def make_graph(config: RunnableConfig):
     # Extract configuration values directly
     configurable = config.get("configurable", {})
     model = configurable.get("model", "anthropic/claude-3-5-sonnet-latest")
-    system_prompt = configurable.get("system_prompt", "You are a helpful AI assistant.")
-    selected_tools = configurable.get("selected_tools", ["get_todays_date"])
+    system_prompt = configurable.get(
+        "system_prompt",
+        (
+            "Eres un asistente que atiende un negocio. "
+            "Cuando completes un pedido, utiliza la herramienta summary_report_tool "
+            "para generar un breve informe resumido. Responde siempre en español."
+        ),
+    )
+    selected_tools = configurable.get(
+        "selected_tools", ["get_todays_date", "summary_report_tool"]
+    )
     
     # Use the configuration
     llm = load_chat_model(model)

--- a/src/react_agent/configuration.py
+++ b/src/react_agent/configuration.py
@@ -8,9 +8,15 @@ class Configuration(BaseModel):
     """The configuration for the agent."""
 
     system_prompt: str = Field(
-        default="You are a helpful AI assistant.",
-        description="The system prompt to use for the agent's interactions. "
-        "This prompt sets the context and behavior for the agent."
+        default=(
+            "Eres un asistente que atiende un negocio. "
+            "Cuando completes un pedido, utiliza la herramienta summary_report_tool "
+            "para generar un breve informe resumido. Responde siempre en español."
+        ),
+        description=(
+            "The system prompt to use for the agent's interactions. "
+            "This prompt sets the context and behavior for the agent."
+        ),
     )
 
     model: Annotated[
@@ -28,7 +34,7 @@ class Configuration(BaseModel):
     )
 
     selected_tools: list[Literal["finance_research", "advanced_research_tool", "basic_research_tool", "get_todays_date", "acronym_tool", "summary_report_tool"]] = Field(
-        default = ["get_todays_date"],
+        default = ["get_todays_date", "summary_report_tool"],
         description="The list of tools to use for the agent's interactions. "
         "This list should contain the names of the tools to use."
     )

--- a/src/react_agent/graph.py
+++ b/src/react_agent/graph.py
@@ -18,8 +18,17 @@ async def make_graph(config: RunnableConfig):
 
     # get values from configuration
     llm = configurable.get("model", "openai/gpt-4.1")
-    selected_tools = configurable.get("selected_tools", ["get_todays_date"])
-    prompt = configurable.get("system_prompt", "You are a helpful assistant.")
+    selected_tools = configurable.get(
+        "selected_tools", ["get_todays_date", "summary_report_tool"]
+    )
+    prompt = configurable.get(
+        "system_prompt",
+        (
+            "Eres un asistente que atiende un negocio. "
+            "Cuando completes un pedido, utiliza la herramienta summary_report_tool "
+            "para generar un breve informe resumido. Responde siempre en español."
+        ),
+    )
     
     # specify the name for use in supervisor architecture
     name = configurable.get("name", "react_agent")


### PR DESCRIPTION
## Summary
- set new Spanish prompt to use `summary_report_tool` after order completion
- include `summary_report_tool` in default tools
- update ReAct agent defaults and README snippet

## Testing
- `pytest -q`
- `pre-commit run --files src/react_agent/configuration.py src/react_agent/graph.py README.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686abc0254e88327a64af614bdc015a4