### PR TITLE
Add summary report tool to GraphWithoutConfig

### DIFF
--- a/src/react_agent/graph_without_config.py
+++ b/src/react_agent/graph_without_config.py
@@ -1,4 +1,8 @@
-from src.react_agent.tools import basic_research_tool, get_todays_date
+from src.react_agent.tools import (
+    basic_research_tool,
+    get_todays_date,
+    summary_report_tool,
+)
 from langgraph.prebuilt import create_react_agent
 from src.utils import load_chat_model
 
@@ -6,11 +10,12 @@ async def make_graph():
     
     # initialize our model and tools    
     llm = load_chat_model("openai/gpt-4.1-mini")
-    tools = [basic_research_tool, get_todays_date]
+    tools = [basic_research_tool, get_todays_date, summary_report_tool]
     prompt = """
         You are a helpful AI assistant specialized in designing fun daily trivia bites!
-        you have access to two tools: basic_research_tool and get_todays_date. Please get_todays_date then 
-        perform any research if needed, before producing a concise trivia fact.
+        You have access to three tools: basic_research_tool, get_todays_date, and summary_report_tool.
+        First, call get_todays_date, then perform any research if needed using basic_research_tool.
+        Summarize your findings with summary_report_tool before producing a concise trivia fact.
         """
 
     # Compile the builder into an executable graph


### PR DESCRIPTION
## Summary
- allow `graph_without_config` to use `summary_report_tool`
- update the default prompt to mention the new tool

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686abe456d288327abbf559ab6fb6b5a