### PR TITLE
Add labeling agent and two-node graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,14 @@ Look at `src/react_agent/graph.py` to see how configuration is added while keepi
 ### Scale to Multi-Agent Configuration
 Explore `src/supervisor/` to see how the same configuration patterns work with multiple specialized agents.
 
+## Two-Node Example
+Use `two_node_graph` to run the ReAct agent followed by a labeling step:
+```bash
+langgraph run two_node_graph -i input="Tu texto aqui"
+```
+This sends your message through the ReAct agent and then labels it with fields like `Name`, `Dirección`, `Producto` y `Horario`.
+
+
 ## Development
 
 ### Configuration Best Practices Shown

--- a/langgraph.json
+++ b/langgraph.json
@@ -1,9 +1,12 @@
 {
-  "dependencies": ["."],
+  "dependencies": [
+    "."
+  ],
   "graphs": {
     "react_agent_no_config": "./src/react_agent/graph_without_config.py:make_graph",
     "react_agent": "./src/react_agent/graph.py:make_graph",
-    "supervisor_prebuilt": "./src/supervisor/supervisor_prebuilt.py:make_supervisor_graph"
+    "supervisor_prebuilt": "./src/supervisor/supervisor_prebuilt.py:make_supervisor_graph",
+    "two_node_graph": "./src/two_node_graph/graph.py:make_two_node_graph"
   },
   "env": ".env"
 }

--- a/src/labeling_agent/graph.py
+++ b/src/labeling_agent/graph.py
@@ -1,0 +1,33 @@
+"""Labeling agent for extracting structured fields from text."""
+
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.runnables import RunnableConfig, RunnableLambda
+
+from src.utils import load_chat_model, get_message_text
+
+
+async def make_graph(config: RunnableConfig):
+    """Build a simple labeling agent.
+
+    The returned runnable expects a text input and labels it with fields like
+    ``Name``, ``Direcci\u00f3n``, ``Producto`` and ``Horario``.
+    """
+    configurable = config.get("configurable", {})
+    model_name = configurable.get("model", "openai/gpt-4.1")
+    system_prompt = configurable.get(
+        "system_prompt",
+        (
+            "Eres un asistente que etiqueta el texto en los campos Name, Direcci\u00f3n, "
+            "Producto y Horario. Devuelve el resultado en formato JSON."
+        ),
+    )
+
+    llm = load_chat_model(model_name)
+
+    prompt = ChatPromptTemplate.from_messages([
+        ("system", system_prompt),
+        ("human", "{text}"),
+    ])
+
+    chain = prompt | llm | RunnableLambda(get_message_text)
+    return chain

--- a/src/two_node_graph/graph.py
+++ b/src/two_node_graph/graph.py
@@ -1,0 +1,32 @@
+"""StateGraph with a ReAct agent followed by a labeling agent."""
+
+from langgraph.graph import StateGraph, END
+from langchain_core.runnables import RunnableConfig, RunnableLambda
+
+from src.utils import get_message_text
+
+from src.react_agent.graph import make_graph as make_react_graph
+from src.labeling_agent.graph import make_graph as make_labeling_graph
+
+
+async def make_two_node_graph(config: RunnableConfig):
+    """Build a two node graph: ReAct agent -> labeling agent."""
+    node1 = await make_react_graph(config)
+    labeler = await make_labeling_graph(config)
+
+    def extract_text(state: dict) -> dict:
+        """Get the latest message text from the ReAct agent output."""
+        messages = state.get("messages")
+        if not messages:
+            return {"text": ""}
+        return {"text": get_message_text(messages[-1])}
+
+    node2 = RunnableLambda(extract_text) | labeler
+
+    graph = StateGraph(dict)
+    graph.add_node("node1", node1)
+    graph.add_node("node2", node2)
+    graph.add_edge("node1", "node2")
+    graph.add_edge("node2", END)
+    graph.set_entry_point("node1")
+    return graph.compile()


### PR DESCRIPTION
## Summary
- add labeling agent for Spanish fields
- build a two-node graph that chains the ReAct agent with the labeling agent
- register the new graph in `langgraph.json`
- document usage in README
- fix two-node graph to pass text from the ReAct agent to the labeler

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686ac2bb88388327978e808cb6ea982c