### PR TITLE
Add labeling agent graph example

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,12 @@ langgraph run two_node_graph -i input="Tu texto aqui"
 ```
 This sends your message through the ReAct agent and then labels it with fields like `Name`, `Dirección`, `Producto` y `Horario`.
 
+## Labeling Agent Example
+Run `labeling_agent` directly to tag a piece of text:
+```bash
+langgraph run labeling_agent -i text="Tu texto aqui"
+```
+This graph applies the labeling step without running the ReAct agent first.
 
 ## Development
 

--- a/langgraph.json
+++ b/langgraph.json
@@ -6,7 +6,8 @@
     "react_agent_no_config": "./src/react_agent/graph_without_config.py:make_graph",
     "react_agent": "./src/react_agent/graph.py:make_graph",
     "supervisor_prebuilt": "./src/supervisor/supervisor_prebuilt.py:make_supervisor_graph",
-    "two_node_graph": "./src/two_node_graph/graph.py:make_two_node_graph"
+    "two_node_graph": "./src/two_node_graph/graph.py:make_two_node_graph",
+    "labeling_agent": "./src/labeling_agent/graph.py:make_graph"
   },
   "env": ".env"
 }


### PR DESCRIPTION
## Summary
- expose `labeling_agent` graph in `langgraph.json`
- document how to run the labeling agent in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686ac8d697e483279a4d9f5edabc1e35