### PR TITLE
Add basic test for two node graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,14 @@ While iterating on your configuration:
 - Create new agent types using the same configuration pattern
 - Debug configuration issues in LangGraph Studio
 
+### Running Tests
+
+After installing dependencies, run the test suite with:
+
+```bash
+pytest
+```
+
 ### `summary_report_tool`
 
 Use this tool to condense conversation into a short structured report.

--- a/tests/test_two_node_graph.py
+++ b/tests/test_two_node_graph.py
@@ -1,0 +1,9 @@
+import pytest
+from langchain_core.runnables import RunnableConfig
+from src.two_node_graph.graph import make_two_node_graph
+
+@pytest.mark.asyncio
+async def test_two_node_graph_ainvoke():
+    config = RunnableConfig(configurable={"model": "openai/gpt-4"})
+    graph = await make_two_node_graph(config)
+    await graph.ainvoke({"input": "test"})


### PR DESCRIPTION
## Summary
- create `tests/test_two_node_graph.py` exercising `make_two_node_graph`
- document how to run tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain_core')*

------
https://chatgpt.com/codex/tasks/task_e_686aca2d64348327aa45743c0dfb8ef3